### PR TITLE
Fix failing test

### DIFF
--- a/tst/canvas.tst
+++ b/tst/canvas.tst
@@ -22,21 +22,11 @@ false
 gap> SetTexTypesetting(canvas, true);
 gap> TexTypesetting(canvas);
 true
-gap> DrawSplash(canvas);
-"<!DOCTYPE html>\n    <html>\n      <head>\n        <meta charset=\"utf-8\" co\
-ntent=\"text/html\" property=\"GAP,francy,d3.v5\"></meta>\n        <link rel=\
-\"stylesheet\" type=\"text/css\" href=\"https://cdn.rawgit.com/mcmartins/franc\
-y/develop/js/extensions/browser/index.css\"></link>\n        <script src=\"htt\
-ps://d3js.org/d3.v5.js\"></script>\n        <script src=\"https://cdn.rawgit.c\
-om/mcmartins/francy/master/js/extensions/browser/francy.bundle.js\"></script>\
-\n        <title>Francy</title>\n      </head>\n      <body>\n        <div id=\
-\"francy\"></div>\n        <script>\n          var francy = new Francy({verbos\
-e: true, appendTo: 'body', callbackHandler: console.log});\n          francy.l\
-oad({\"version\" : \"1.2.4\",\"mime\" : \"application\\/vnd.francy+json\",\"ca\
-nvas\" : {\"width\" : 400,\"id\" : \"F16\",\"height\" : 400,\"title\" : \"Quat\
-ernion Group Subgroup Lattice\",\"zoomToFit\" : false,\"texTypesetting\" : tru\
-e,\"menus\" : {},\"graph\" : {},\"chart\" : {},\"messages\" : {}}}).render();\
-\n        </script>\n      </body>\n    </html>"
+gap> splash:=DrawSplash(canvas);;
+gap> IsString(splash);
+true
+gap> StartsWith(splash, "<!DOCTYPE html>\n");
+true
 gap> PrintObj(canvas);
 rec(
   chart := rec(


### PR DESCRIPTION
The string returned by DrawSplash() can differ based on the order of
some dict entries, and thus fails for me. Resolve this by instead only
performing a cursory check of the return value.
