### PR TITLE
Don't use bin/gap.sh

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         gap-branch:
           - master
+          - stable-4.13
           - stable-4.12
 
     steps:
@@ -38,13 +39,16 @@ jobs:
         run: |
           sudo apt update && 
           sudo apt install libzmq3-dev -y
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gap-actions/setup-gap@v2
         with:
           GAP_PKGS_TO_BUILD: "datastructures json uuid io profiling crypting zeromqinterface jupyterkernel"
           GAPBRANCH: ${{ matrix.gap-branch }}
       - uses: gap-actions/build-pkg@v1
       - uses: gap-actions/run-pkg-tests@v2
+      - uses: gap-actions/run-pkg-tests@v2
+        with:
+          only-needed: true
       - uses: gap-actions/process-coverage@v2
       - uses: codecov/codecov-action@v3
 
@@ -56,7 +60,7 @@ jobs:
         node-version: [ 19.x ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up chromedriver
         run: |
           sudo apt update &&
@@ -103,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Configure ZMQ repos
         run: |
           sudo touch /etc/apt/sources.list.d/opensuse.list &&

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -75,7 +75,7 @@ jobs:
 #          # Run Release Script
 #          git config --global user.email "noreply@none.no"
 #          git config --global user.name "GitHubActionRELEASE"
-#          GAP="$HOME/gap/bin/gap.sh" bash -x $HOME/ReleaseTools/release-gap-package --force --push --token ${GH_TOKEN}
+#          GAP="$HOME/gap/gap" bash -x $HOME/ReleaseTools/release-gap-package --force --push --token ${GH_TOKEN}
 
   publish_js_python_packages:
     #needs: gap_release_tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt update && apt -qq install -y git curl wget python3-pip inkscape pandoc t
     rm -rf /opt/master/packages.tar.gz && chown -R jovyan: /opt/master/ && \
     cd /opt/master/pkg/jupyterkernel && pip install . && \
     ln -s /opt/master/pkg/francy/notebooks /home/jovyan/notebooks && \
-    ln -s /opt/master/bin/gap.sh /usr/local/sbin/gap && \
+    ln -s /opt/master/gap /usr/local/sbin/gap && \
     apt purge git gcc g++ make autoconf curl wget -y
 
 USER jovyan


### PR DESCRIPTION
GAP only provides it for backwards compatibility with old GAP versions.
Since GAP 4.9 one should instead just call the gap binary directly.
